### PR TITLE
viewName이 wiki일 때에만 별표 상태 및 개수가 표시되도록 함

### DIFF
--- a/layout.vue
+++ b/layout.vue
@@ -108,7 +108,7 @@
                                     <span class="fa fa-star"></span>
                                     <span class="star-count">{{ $store.state.page.data.star_count ? $store.state.page.data.star_count : '' }}</span>
                                 </nuxt-link>
-                                <nuxt-link  v-else 
+                                <nuxt-link  v-else-if="$store.state.page.viewName === 'wiki'"
                                             :to="doc_action_link($store.state.page.data.document, 'member/star')"
                                             class="dropdown-item">
                                     <span class="fa fa-star-o"></span>


### PR DESCRIPTION
unstar 링크 쪽은 어차피 viewName이 wiki가 아니면 $store.state.page.data.starred 라는 조건을 충족할 수 없기 때문에 (값 자체가 없으므로) 별도의 추가 조건을 요하지 않으므로 놔뒀습니다.