### PR TITLE
Add content tools (used dropdown)

### DIFF
--- a/components/contentTool.vue
+++ b/components/contentTool.vue
@@ -45,7 +45,7 @@ export default {
     methods: {
         onClickEditBtn() {
             if (this.$store.state.localConfig['liberty.showEditMessage']) {
-                if (this.requestable)
+                if (this.$store.state.page.data.editable === true && this.$store.state.page.data.edit_acl_message)
                     this.$router.push(this.doc_action_link(this.$store.state.page.data.document, 'new_edit_request'));
                 else
                     this.$router.push(this.doc_action_link(this.$store.state.page.data.document, 'edit'));

--- a/components/contentTool.vue
+++ b/components/contentTool.vue
@@ -42,6 +42,24 @@ import Common from '~/mixins/common';
 
 export default {
     mixins: [Common],
+    methods: {
+        onClickEditBtn() {
+            if (this.$store.state.localConfig['liberty.showEditMessage']) {
+                if (this.requestable)
+                    this.$router.push(this.doc_action_link(this.$store.state.page.data.document, 'new_edit_request'));
+                else
+                    this.$router.push(this.doc_action_link(this.$store.state.page.data.document, 'edit'));
+            }
+            else {
+                this.$store.commit('localConfigSetValue', {key: 'liberty.showEditMessage', value: true});
+            }
+        }
+    },
+    watch: {
+        $route(to, from) {
+            this.$store.commit('localConfigSetValue', {key: 'liberty.showEditMessage', value: false});
+        }
+    },
     computed: {
         toolList() {
             const tools = [];

--- a/components/contentTool.vue
+++ b/components/contentTool.vue
@@ -1,0 +1,78 @@
+<template>
+    <div v-if="toolList.length" class="content-tools">
+        <div class="btn-group" role="group" aria-label="content-tools">
+            <template v-if="toolList.includes('star')">
+                <nuxt-link v-if="$store.state.page.data.starred" :to="doc_action_link($store.state.page.data.document, 'member/unstar')" class="btn btn-secondary tools-btn" v-tooltip="`Unstar`">
+                    <span class="fa fa-star"></span>
+                    <span class="star-count">{{ $store.state.page.data.star_count }}</span>
+                </nuxt-link>
+                <nuxt-link v-else-if="$store.state.page.data.star_count || $store.state.page.data.star_count === 0" :to="doc_action_link($store.state.page.data.document, 'member/star')" class="btn btn-secondary tools-btn" v-tooltip="`Star`">
+                    <span class="fa fa-star-o"></span>
+                    <span class="star-count">{{ $store.state.page.data.star_count }}</span>
+                </nuxt-link>
+            </template>
+            <nuxt-link v-if="toolList.includes('backlink')" :to="doc_action_link($store.state.page.data.document, 'backlink')" class="btn btn-secondary tools-btn">역링크</nuxt-link>
+            <nuxt-link v-if="toolList.includes('discuss')" :to="doc_action_link($store.state.page.data.document, 'discuss')" class="btn btn-secondary tools-btn" :class="{ 'btn-discuss-progress': $store.state.page.data.discuss_progress }">토론</nuxt-link>
+            <template v-if="toolList.includes('edit')">
+                <a v-if="$store.state.page.data.editable === true && $store.state.page.data.edit_acl_message" href="#" @click.prevent="onClickEditBtn" class="btn btn-secondary tools-btn"><span class="fa fa-pencil-square"></span> 편집 요청</a>
+                <a v-else-if="$store.state.page.data.editable === false && $store.state.page.data.edit_acl_message" href="#" @click.prevent="onClickEditBtn" class="btn btn-secondary tools-btn"><span class="fa fa-lock"></span> 편집</a>
+                <nuxt-link v-else :to="doc_action_link($store.state.page.data.document, 'edit')" class="btn btn-secondary tools-btn"><span class="fa fa-edit"></span> 편집</nuxt-link>
+            </template>
+            <nuxt-link v-if="toolList.includes('history')" :to="doc_action_link($store.state.page.data.document, 'history')" class="btn btn-secondary tools-btn">역사</nuxt-link>
+            <nuxt-link v-if="toolList.includes('acl')" :to="doc_action_link($store.state.page.data.document, 'acl')" class="btn btn-secondary tools-btn">ACL</nuxt-link>
+            <nuxt-link v-if="toolList.includes('delete')" :to="doc_action_link($store.state.page.data.document, 'delete')" class="btn btn-danger tools-btn">삭제</nuxt-link>
+            <nuxt-link v-if="toolList.includes('move')" :to="doc_action_link($store.state.page.data.document, 'move')"  class="btn btn-secondary tools-btn">이동</nuxt-link>
+            <template v-if="true">
+                <button type="button" class="btn btn-secondary tools-btn dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><span class="caret"></span></button>
+                <div class="dropdown-menu dropdown-menu-right" role="menu">
+                    <nuxt-link v-if="toolList.includes('contribution')" :to="contribution_author_link($store.state.page.data.document.title)" class="dropdown-item">기여 내역</nuxt-link>
+                    <nuxt-link v-if="toolList.includes('raw')" :to="doc_action_link($store.state.page.data.document, 'raw', $store.state.page.data.rev ? { rev: $store.state.page.data.rev } : undefined)" class="dropdown-item">RAW</nuxt-link>
+                    <nuxt-link v-if="toolList.includes('blame')" :to="doc_action_link($store.state.page.data.document, 'blame', $store.state.page.data.rev ? { rev: $store.state.page.data.rev } : undefined)" class="dropdown-item">Blame</nuxt-link>
+                    <nuxt-link v-if="toolList.includes('diff')" :to="doc_action_link($store.state.page.data.document, 'diff', $store.state.page.data.rev ? { rev: $store.state.page.data.rev, oldrev: $store.state.page.data.rev - 1 } : undefined)" class="dropdown-item">이전 리버전과 비교</nuxt-link>
+                    <nuxt-link v-if="toolList.includes('revert')" :to="doc_action_link($store.state.page.data.document, 'revert', $store.state.page.data.rev ? { rev: $store.state.page.data.rev } : undefined)" class="dropdown-item">이 리버전으로 되돌리기</nuxt-link>
+                    <nuxt-link v-if="toolList.includes('menu')" v-for="m in $store.state.page.data.menus" :key="m.to" :to="m.to" class="dropdown-item" v-text="m.title" />
+                </div>
+            </template>
+        </div>
+    </div>
+</template>
+
+<script>
+import Common from '~/mixins/common';
+
+export default {
+    mixins: [Common],
+    computed: {
+        toolList() {
+            const tools = [];
+            switch (this.$store.state.page.viewName) {
+                case 'wiki':
+                case 'notfound':
+                    tools.push('star', 'backlink', 'discuss', 'edit', 'history', 'acl', 'raw', 'blame', 'diff');
+                    if (this.$store.state.page.data.user) tools.push('contribution');
+                    if (this.$store.state.page.data.rev) tools.push('revert');
+                    break;
+                case 'backlink':
+                    tools.push('history', 'edit');
+                    break;
+                case 'edit':
+                case 'edit_edit_request':
+                    tools.push('backlink', 'delete', 'move');
+                    break;
+                case 'history':
+                    tools.push('edit', 'backlink');
+                    break;
+                case 'raw':
+                case 'diff':
+                    tools.push('history', 'edit', 'backlink');
+                    break;
+                case 'thread':
+                    tools.push('discuss');
+                    break;
+            }
+            if (this.$store.state.page.data.menus?.length) tools.push('menu');
+            return tools;
+        }
+    }
+}
+</script>

--- a/components/contentTool.vue
+++ b/components/contentTool.vue
@@ -22,7 +22,7 @@
             <nuxt-link v-if="toolList.includes('acl')" :to="doc_action_link($store.state.page.data.document, 'acl')" class="btn btn-secondary tools-btn">ACL</nuxt-link>
             <nuxt-link v-if="toolList.includes('delete')" :to="doc_action_link($store.state.page.data.document, 'delete')" class="btn btn-danger tools-btn">삭제</nuxt-link>
             <nuxt-link v-if="toolList.includes('move')" :to="doc_action_link($store.state.page.data.document, 'move')"  class="btn btn-secondary tools-btn">이동</nuxt-link>
-            <template v-if="true">
+            <template v-if="toolList.includes('contribution') || toolList.includes('raw') || toolList.includes('blame') || toolList.includes('diff') || toolList.includes('revert') || toolList.includes('menu')">
                 <button type="button" class="btn btn-secondary tools-btn dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><span class="caret"></span></button>
                 <div class="dropdown-menu dropdown-menu-right" role="menu">
                     <nuxt-link v-if="toolList.includes('contribution')" :to="contribution_author_link($store.state.page.data.document.title)" class="dropdown-item">기여 내역</nuxt-link>

--- a/components/diffSelector.vue
+++ b/components/diffSelector.vue
@@ -1,7 +1,7 @@
 <template>
     <div v-if="this.$route.query.rev && $store.state.page.viewName === 'diff'">
         <ul class="pagination pagination-sm">
-            <li class="page-item" :class="{ disabled: currentPage === 1 }">
+            <li class="page-item" :class="{ disabled: currentPage === 0 }">
                 <a class="page-link" href="#" @click.prevent="prevPage"><span class="ion-ios-arrow-back"></span> Prev</a>
             </li>
             <li v-for="n in count" :key="rev - n - currentPage * 10" class="page-item">

--- a/components/diffSelector.vue
+++ b/components/diffSelector.vue
@@ -1,11 +1,11 @@
 <template>
-    <div v-if="this.$route.query.rev && $store.state.page.viewName === 'diff'">
+    <div v-if="$route.query.rev && $store.state.page.viewName === 'diff'">
         <ul class="pagination pagination-sm">
             <li class="page-item" :class="{ disabled: currentPage === 0 }">
                 <a class="page-link" href="#" @click.prevent="prevPage"><span class="ion-ios-arrow-back"></span> Prev</a>
             </li>
             <li v-for="n in count" :key="rev - n - currentPage * 10" class="page-item">
-                <nuxt-link :to="doc_action_link(this.$store.state.page.data.document, 'diff', { rev, oldrev: rev - n - currentPage * 10 })" class="page-link">{{ rev - n - currentPage * 10 }}</nuxt-link>
+                <nuxt-link :to="doc_action_link($store.state.page.data.document, 'diff', { rev, oldrev: rev - n - currentPage * 10 })" class="page-link">{{ rev - n - currentPage * 10 }}</nuxt-link>
             </li>
             <li class="page-item" :class="{ disabled: currentPage === pageCount }">
                 <a class="page-link" href="#" @click.prevent="nextPage">Next <span class="ion-ios-arrow-forward"></span></a>

--- a/components/diffSelector.vue
+++ b/components/diffSelector.vue
@@ -17,6 +17,8 @@
 <style scoped>
 .pagination {
     margin-top: 0;
+    justify-content: center;
+    display: flex;
 }
 </style>
 

--- a/components/revSelector.vue
+++ b/components/revSelector.vue
@@ -1,11 +1,11 @@
 <template>
-    <div v-if="$route.query.rev && $store.state.page.viewName === 'diff'">
+    <div v-if="($store.state.page.data.rev || $route.query.rev) && ($store.state.page.viewName === 'diff' || $store.state.page.viewName === 'blame')">
         <ul class="pagination pagination-sm">
             <li class="page-item" :class="{ disabled: currentPage === 0 }">
                 <a class="page-link" href="#" @click.prevent="prevPage"><span class="ion-ios-arrow-back"></span> Prev</a>
             </li>
             <li v-for="n in count" :key="rev - n - currentPage * 10" class="page-item">
-                <nuxt-link :to="doc_action_link($store.state.page.data.document, 'diff', { rev, oldrev: rev - n - currentPage * 10 })" class="page-link">{{ rev - n - currentPage * 10 }}</nuxt-link>
+                <nuxt-link :to="generateItemLink(n)" class="page-link">{{ rev - n - currentPage * 10 }}</nuxt-link>
             </li>
             <li class="page-item" :class="{ disabled: currentPage === pageCount }">
                 <a class="page-link" href="#" @click.prevent="nextPage">Next <span class="ion-ios-arrow-forward"></span></a>
@@ -20,6 +20,11 @@
     justify-content: center;
     display: flex;
 }
+
+.theseed-dark-mode .pagination .page-item .page-link {
+    background-color: #27292d;
+    border-color: #383b40;
+}
 </style>
 
 <script>
@@ -30,7 +35,7 @@ export default {
     data() {
         return {
             currentPage: 0,
-        };
+        }
     },
     methods: {
         prevPage() {
@@ -43,10 +48,18 @@ export default {
                 this.currentPage++;
             }
         },
+        generateItemLink(n) {
+            if (this.$store.state.page.viewName === 'diff') {
+                return this.doc_action_link(this.$store.state.page.data.document, 'diff', { rev: this.rev, oldrev: this.rev - n - this.currentPage * 10 })
+            }
+            else if (this.$store.state.page.viewName === 'blame') {
+                return this.doc_action_link(this.$store.state.page.data.document, 'blame', { rev: this.rev - n - this.currentPage * 10 })
+            }
+        }
     },
     computed: {
         rev() {
-            return this.$route.query.rev;
+            return this.$store.state.page.data.rev || this.$route.query.rev;
         },
         pageCount() {
             return Math.floor(this.rev / 10);

--- a/layout.vue
+++ b/layout.vue
@@ -144,7 +144,7 @@
                         </button>
                         현재 진행 중인 <nuxt-link :to="doc_action_link(user_doc($store.state.session.member.username), 'discuss')">사용자 토론</nuxt-link>이 있습니다.
                     </div>
-                    <diff-selector />
+                    <rev-selector />
                     <nuxt />
                     <div v-if="$store.state.page.viewName === 'license'">
                         <h2>Liberty skin license</h2>
@@ -870,7 +870,7 @@ import LocalDate from '~/components/localDate';
 import RecentCard from './components/recentCard';
 import SearchForm from './components/searchForm';
 import ContentTool from './components/contentTool';
-import DiffSelector from './components/diffSelector';
+import RevSelector from './components/revSelector';
 
 if (process.browser) {
     try {
@@ -889,7 +889,7 @@ export default {
         RecentCard,
         SearchForm,
         ContentTool,
-        DiffSelector
+        RevSelector
     },
     computed: {
         skinConfig() {

--- a/layout.vue
+++ b/layout.vue
@@ -133,7 +133,7 @@
                     </div>
                 </div>
                 <div class="liberty-content-main wiki-article">
-                    <div v-if="$store.state.page.data.edit_acl_message && showEditMessage" class="alert alert-danger" role="alert">
+                    <div v-if="$store.state.page.data.edit_acl_message && $store.state.localConfig['liberty.showEditMessage']" class="alert alert-danger" role="alert">
                         <span v-html="$store.state.page.data.edit_acl_message" @click="onDynamicContentClick($event)"></span>
                         <span v-if="requestable">대신 <nuxt-link :to="doc_action_link($store.state.page.data.document, 'new_edit_request')">편집 요청</nuxt-link>을 생성할 수 있습니다.</span>
                     </div>

--- a/layout.vue
+++ b/layout.vue
@@ -125,8 +125,6 @@
                                 <a v-else-if="$store.state.page.data.editable === false && $store.state.page.data.edit_acl_message" href="#" @click.prevent="onClickEditBtn" class="btn btn-secondary tools-btn"><span class="fa fa-lock"></span> 편집</a>
                                 <nuxt-link v-else :to="doc_action_link($store.state.page.data.document, 'edit')" class="btn btn-secondary tools-btn"><span class="fa fa-edit"></span> 편집</nuxt-link>
                                 <nuxt-link :to="doc_action_link($store.state.page.data.document, 'history')"  class="btn btn-secondary tools-btn">역사</nuxt-link>
-                                <nuxt-link v-if="$store.state.page.data.user"
-                                        :to="contribution_author_link($store.state.page.data.document.title)" class="btn btn-secondary tools-btn">기여</nuxt-link>
                                 <nuxt-link :to="doc_action_link($store.state.page.data.document, 'acl')"  class="btn btn-secondary tools-btn">ACL</nuxt-link>
                             </template>
                             <template v-else-if="viewName === 'backlink'">
@@ -150,8 +148,27 @@
                             <template v-else-if="viewName === 'thread'">
                                 <nuxt-link :to="doc_action_link($store.state.page.data.document, 'discuss')"  class="btn btn-secondary tools-btn">토론 목록</nuxt-link>
                             </template>
-                            <template v-if="$store.state.page.data.menus && $store.state.page.data.menus.length">
-                                <nuxt-link v-for="m in $store.state.page.data.menus" :key="m.to" :to="m.to" class="btn btn-secondary tools-btn" v-text="m.title" />
+                            <template v-if="$store.state.page.viewName === 'wiki' || ($store.state.page.data.menus && $store.state.page.data.menus.length) || $store.state.page.data.user">
+                                <button type="button" class="btn btn-secondary tools-btn dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+                                    <span class="caret"></span>
+                                </button>
+                                <div class="dropdown-menu dropdown-menu-right" role="menu">
+                                    <nuxt-link v-if="$store.state.page.data.user" :to="contribution_author_link($store.state.page.data.document.title)" class="dropdown-item">기여 내역</nuxt-link>
+                                    <template v-if="$store.state.page.viewName === 'wiki' && $store.state.page.data.rev">
+                                        <nuxt-link :to="doc_action_link($store.state.page.data.document, 'raw', { rev: $store.state.page.data.rev })" class="dropdown-item">RAW</nuxt-link>
+                                        <nuxt-link :to="doc_action_link($store.state.page.data.document, 'blame', { rev: $store.state.page.data.rev })" class="dropdown-item">Blame</nuxt-link>
+                                        <nuxt-link :to="doc_action_link($store.state.page.data.document, 'diff', { rev: $store.state.page.data.rev, oldrev: $store.state.page.data.rev - 1 })" class="dropdown-item">이전 리버전과 비교</nuxt-link>
+                                        <nuxt-link :to="doc_action_link($store.state.page.data.document, 'revert', { rev: $store.state.page.data.rev })" class="dropdown-item">이 리버전으로 되돌리기</nuxt-link>
+                                    </template>
+                                    <template v-if="$store.state.page.viewName === 'wiki' && $store.state.page.data.rev === null">
+                                        <nuxt-link :to="doc_action_link($store.state.page.data.document, 'raw')" class="dropdown-item">RAW</nuxt-link>
+                                        <nuxt-link :to="doc_action_link($store.state.page.data.document, 'blame')" class="dropdown-item">Blame</nuxt-link>
+                                        <nuxt-link :to="doc_action_link($store.state.page.data.document, 'diff')" class="dropdown-item">이전 리버전과 비교</nuxt-link>
+                                    </template>
+                                    <template v-if="$store.state.page.data.menus && $store.state.page.data.menus.length">
+                                        <nuxt-link v-for="m in $store.state.page.data.menus" :key="m.to" :to="m.to" class="dropdown-item" v-text="m.title" />
+                                    </template>
+                                </div>
                             </template>
                         </div>
                     </div>

--- a/layout.vue
+++ b/layout.vue
@@ -891,28 +891,6 @@ export default {
         ContentTool,
         DiffSelector
     },
-    data(){
-        return {
-            showEditMessage: false
-        }
-    },
-    methods: {
-        onClickEditBtn() {
-            if (this.showEditMessage) {
-                if (this.requestable)
-                    this.$router.push(this.doc_action_link(this.$store.state.page.data.document, 'new_edit_request'));
-                else
-                    this.$router.push(this.doc_action_link(this.$store.state.page.data.document, 'edit'));
-            }
-
-            this.showEditMessage = !this.showEditMessage;
-        }
-    },
-    watch: {
-        $route(to, from) {
-            this.showEditMessage = false;
-        }
-    },
     computed: {
         skinConfig() {
             return {

--- a/layout.vue
+++ b/layout.vue
@@ -106,72 +106,7 @@
                     <span class="label label-danger" v-html="$store.state.config['wiki.sitenotice']" />
                 </div>
                 <div class="liberty-content-header">
-                    <div v-if="viewName || ($store.state.page.data.menus && $store.state.page.data.menus.length)" class="content-tools">
-                        <div class="btn-group" role="group" aria-label="content-tools">
-                            <template v-if="viewName === 'wiki' || viewName === 'notfound'">
-                                <nuxt-link v-if="$store.state.page.data.starred"
-                                        :to="doc_action_link($store.state.page.data.document, 'member/unstar')" class="btn btn-secondary tools-btn" v-tooltip="`Unstar`">
-                                    <span class="fa fa-star"></span>
-                                    <span class="star-count">{{ $store.state.page.data.star_count }}</span>
-                                </nuxt-link>
-                                <nuxt-link v-else-if="$store.state.page.data.star_count || $store.state.page.data.star_count === 0"
-                                        :to="doc_action_link($store.state.page.data.document, 'member/star')" class="btn btn-secondary tools-btn" v-tooltip="`Star`">
-                                    <span class="fa fa-star-o"></span>
-                                    <span class="star-count">{{ $store.state.page.data.star_count }}</span>
-                                </nuxt-link>
-                                <nuxt-link :to="doc_action_link($store.state.page.data.document, 'backlink')" class="btn btn-secondary tools-btn">역링크</nuxt-link>
-                                <nuxt-link :to="doc_action_link($store.state.page.data.document, 'discuss')"  class="btn btn-secondary tools-btn" :class="{ 'btn-discuss-progress': $store.state.page.data.discuss_progress }">토론</nuxt-link>
-                                <a v-if="requestable" href="#" @click.prevent="onClickEditBtn" class="btn btn-secondary tools-btn"><span class="fa fa-pencil-square"></span> 편집 요청</a>
-                                <a v-else-if="$store.state.page.data.editable === false && $store.state.page.data.edit_acl_message" href="#" @click.prevent="onClickEditBtn" class="btn btn-secondary tools-btn"><span class="fa fa-lock"></span> 편집</a>
-                                <nuxt-link v-else :to="doc_action_link($store.state.page.data.document, 'edit')" class="btn btn-secondary tools-btn"><span class="fa fa-edit"></span> 편집</nuxt-link>
-                                <nuxt-link :to="doc_action_link($store.state.page.data.document, 'history')"  class="btn btn-secondary tools-btn">역사</nuxt-link>
-                                <nuxt-link :to="doc_action_link($store.state.page.data.document, 'acl')"  class="btn btn-secondary tools-btn">ACL</nuxt-link>
-                            </template>
-                            <template v-else-if="viewName === 'backlink'">
-                                <nuxt-link :to="doc_action_link($store.state.page.data.document, 'history')"  class="btn btn-secondary tools-btn">역사</nuxt-link>
-                                <nuxt-link :to="doc_action_link($store.state.page.data.document, 'edit')" class="btn btn-secondary tools-btn">편집</nuxt-link>
-                            </template>
-                            <template v-else-if="viewName === 'edit' || viewName === 'edit_edit_request'">
-                                <nuxt-link :to="doc_action_link($store.state.page.data.document, 'backlink')" class="btn btn-secondary tools-btn">역링크</nuxt-link>
-                                <nuxt-link :to="doc_action_link($store.state.page.data.document, 'delete')" class="btn btn-danger tools-btn">삭제</nuxt-link>
-                                <nuxt-link :to="doc_action_link($store.state.page.data.document, 'move')"  class="btn btn-secondary tools-btn">이동</nuxt-link>
-                            </template>
-                            <template v-else-if="viewName === 'history'">
-                                <nuxt-link :to="doc_action_link($store.state.page.data.document, 'edit')" class="btn btn-secondary tools-btn">편집</nuxt-link>
-                                <nuxt-link :to="doc_action_link($store.state.page.data.document, 'backlink')" class="btn btn-secondary tools-btn">역링크</nuxt-link>
-                            </template>
-                            <template v-else-if="viewName === 'raw' || viewName === 'diff'">
-                                <nuxt-link :to="doc_action_link($store.state.page.data.document, 'history')"  class="btn btn-secondary tools-btn">역사</nuxt-link>
-                                <nuxt-link :to="doc_action_link($store.state.page.data.document, 'edit')" class="btn btn-secondary tools-btn">편집</nuxt-link>
-                                <nuxt-link :to="doc_action_link($store.state.page.data.document, 'backlink')" class="btn btn-secondary tools-btn">역링크</nuxt-link>
-                            </template>
-                            <template v-else-if="viewName === 'thread'">
-                                <nuxt-link :to="doc_action_link($store.state.page.data.document, 'discuss')"  class="btn btn-secondary tools-btn">토론 목록</nuxt-link>
-                            </template>
-                            <template v-if="$store.state.page.viewName === 'wiki' || ($store.state.page.data.menus && $store.state.page.data.menus.length) || $store.state.page.data.user">
-                                <button type="button" class="btn btn-secondary tools-btn dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-                                    <span class="caret"></span>
-                                </button>
-                                <div class="dropdown-menu dropdown-menu-right" role="menu">
-                                    <nuxt-link v-if="$store.state.page.data.user" :to="contribution_author_link($store.state.page.data.document.title)" class="dropdown-item">기여 내역</nuxt-link>
-                                    <template v-if="$store.state.page.viewName === 'wiki' && $store.state.page.data.rev">
-                                        <nuxt-link :to="doc_action_link($store.state.page.data.document, 'raw', { rev: $store.state.page.data.rev })" class="dropdown-item">RAW</nuxt-link>
-                                        <nuxt-link :to="doc_action_link($store.state.page.data.document, 'blame', { rev: $store.state.page.data.rev })" class="dropdown-item">Blame</nuxt-link>
-                                        <nuxt-link :to="doc_action_link($store.state.page.data.document, 'diff', { rev: $store.state.page.data.rev, oldrev: $store.state.page.data.rev - 1 })" class="dropdown-item">이전 리버전과 비교</nuxt-link>
-                                        <nuxt-link :to="doc_action_link($store.state.page.data.document, 'revert', { rev: $store.state.page.data.rev })" class="dropdown-item">이 리버전으로 되돌리기</nuxt-link>
-                                    </template>
-                                    <template v-if="$store.state.page.viewName === 'wiki' && $store.state.page.data.rev === null">
-                                        <nuxt-link :to="doc_action_link($store.state.page.data.document, 'raw')" class="dropdown-item">RAW</nuxt-link>
-                                        <nuxt-link :to="doc_action_link($store.state.page.data.document, 'blame')" class="dropdown-item">Blame</nuxt-link>
-                                        <nuxt-link :to="doc_action_link($store.state.page.data.document, 'diff')" class="dropdown-item">이전 리버전과 비교</nuxt-link>
-                                    </template>
-                                    <template v-if="$store.state.page.data.menus && $store.state.page.data.menus.length">
-                                        <nuxt-link v-for="m in $store.state.page.data.menus" :key="m.to" :to="m.to" class="dropdown-item" v-text="m.title" />
-                                    </template>
-                                </div>
-                            </template>
-                        </div>
-                    </div>
+                    <content-tool />
                     <div class="title">
                         <h1 v-if="$store.state.page.data.document && $store.state.page.viewName !== 'error'">
                             <nuxt-link :to="doc_action_link($store.state.page.data.document, 'w')"><span v-if="$store.state.page.data.document.forceShowNamespace !== false" class="namespace">{{$store.state.page.data.document.namespace}}:</span>{{$store.state.page.data.document.title}}</nuxt-link>
@@ -933,6 +868,7 @@ import SettingItemCheckbox from '~/components/settingItemCheckbox';
 import LocalDate from '~/components/localDate';
 import RecentCard from './components/recentCard';
 import SearchForm from './components/searchForm';
+import ContentTool from './components/contentTool';
 
 if (process.browser) {
     try {
@@ -949,7 +885,8 @@ export default {
         SettingItemCheckbox,
         LocalDate,
         RecentCard,
-        SearchForm
+        SearchForm,
+        ContentTool
     },
     data(){
         return {
@@ -984,9 +921,6 @@ export default {
                 '--liberty-navbar-logo-padding': this.$store.state.config['skin.liberty.navbar_logo_padding'],
                 '--liberty-navbar-logo-margin': this.$store.state.config['skin.liberty.navbar_logo_margin'],
             };
-        },
-        viewName() {
-            return ['wiki', 'notfound', 'backlink', 'edit', 'edit_edit_request', 'history', 'raw', 'diff', 'thread'].includes(this.$store.state.page.viewName) ? this.$store.state.page.viewName : false;
         },
         requestable() {
             return this.$store.state.page.data.editable === true && this.$store.state.page.data.edit_acl_message;


### PR DESCRIPTION
문서를 볼 때마다 문서에서 바로 raw, blame을 바로 갈 수 있는 버튼이 있었으면 좋겠다고 생각이 돼서 만들어 보았는데 덕지덕지인 느낌이 살짝 있어서 호불호가 갈리면 설정 기능이나 삭제하도록 하겠습니다.

rev-selector 기능 설명
1. 비교에서 비교 대상 리버전(oldrev) 선택 가능
2. Blame에서 이전 리버전 선택 가능 (되돌린 리버전의 경우 blame 링크가 걸려있긴 하지만 조금씩 변경된 경우 리버전 찾기가 어려워 한칸씩 리버전을 옮길 수 있는 유저 편의성 개선)
3. 개인적으로 스킨 단독 기능 하나쯤 있었으면 좋겠어서 만들어봄