### PR TITLE
Use skin.liberty.brand_color_1 instead of skin.liberty.navbar_color

### DIFF
--- a/components/fromSelector.vue
+++ b/components/fromSelector.vue
@@ -1,0 +1,60 @@
+<template>
+    <div v-if="$store.state.localConfig['liberty.rev_selector'] !== false && $store.state.page.viewName === 'history'">
+        <input v-model="revInput" type="text" inputmode="numeric" pattern="\d*" class="form-control" placeholder="rev">
+        <button @click="onClickSearch" type="button" class="btn btn-secondary">
+            <span class="fa fa-search"></span>
+        </button>
+    </div>
+</template>
+
+<style scoped>
+div {
+    float: right;
+    margin: 1rem;
+}
+
+input {
+    width: 5rem;
+    display: inline-block;
+}
+
+button > .fa {
+    font-size: 0.9rem;
+}
+
+.theseed-dark-mode input,
+.theseed-dark-mode button {
+    background-color: #27292d;
+    border-color: #383b40;
+    color: #ddd;
+}
+
+.theseed-dark-mode button:hover {
+    background-color: #2d2f34;
+    border-color: #383b40;
+}
+</style>
+
+<script>
+import Common from '~/mixins/common';
+
+export default {
+    mixins: [Common],
+    data() {
+        return {
+            revInput: this.$route.query.from ?? ''
+        }
+    },
+    methods: {
+        onClickSearch() {
+            if (!this.revInput) return;
+            this.$router.push(this.doc_action_link(this.$store.state.page.data.document, 'history', { from: this.revInput }));
+        }
+    },
+    watch: {
+        '$route.query.from'() {
+            this.revInput = this.$route.query.from;
+        }
+    }
+}
+</script>

--- a/components/searchForm.vue
+++ b/components/searchForm.vue
@@ -34,13 +34,8 @@ export default {
         }
     },
     watch: {
-        $route(to, from) {
-            if (this.$store.state.localConfig["liberty.reset_search_on_move"] !== false) {
-                this.searchTextModel = '';
-                this.searchText = '';
-                this.cursor = -1;
-                this.items = [];
-            }
+        $route() {
+            if (this.$store.state.localConfig["liberty.reset_search_on_move"] !== false) this.reset();
         }
     }
 }

--- a/css/dark.css
+++ b/css/dark.css
@@ -88,6 +88,7 @@ body.theseed-dark-mode {
 	color: #ddd;
 }
 
+.theseed-dark-mode .dropdown-menu .dropdown-item:focus,
 .theseed-dark-mode .dropdown-menu .dropdown-item:hover {
 	background-color: #383b40;
 }
@@ -98,6 +99,10 @@ body.theseed-dark-mode {
 .theseed-dark-mode .Liberty .content-wrapper .liberty-sidebar .liberty-right-fixed .live-recent .live-recent-header .nav .nav-item .nav-link:hover {
 	background: black;
 	color: #ddd;
+}
+
+.theseed-dark-mode .Liberty .content-wrapper .liberty-sidebar .liberty-right-fixed .live-recent .live-recent-header .nav .nav-item .nav-link.active::before {
+	border-color: #e1e8ed;
 }
 
 .theseed-dark-mode .Liberty .content-wrapper .liberty-sidebar .liberty-right-fixed .live-recent .live-recent-content .live-recent-list .recent-item {

--- a/css/dark.css
+++ b/css/dark.css
@@ -57,6 +57,19 @@ body.theseed-dark-mode {
     background-color: #438a83;
 }
 
+.theseed-dark-mode .Liberty .content-wrapper .liberty-content .liberty-content-header,
+.theseed-dark-mode .Liberty .content-wrapper .liberty-content .liberty-content-main,
+.theseed-dark-mode .Liberty .content-wrapper .liberty-footer {
+	border-color: #777;
+}
+
+.theseed-dark-mode .Liberty .content-wrapper .liberty-sidebar .liberty-right-fixed .live-recent .live-recent-header .nav .nav-item,
+.theseed-dark-mode .Liberty .content-wrapper .liberty-sidebar .liberty-right-fixed .live-recent .live-recent-content .live-recent-list li,
+.theseed-dark-mode .Liberty .content-wrapper .liberty-sidebar .liberty-right-fixed .live-recent .live-recent-footer,
+.theseed-dark-mode .Liberty .content-wrapper .liberty-sidebar .liberty-right-fixed .live-recent .live-recent-content {
+	border-color: #777;
+}
+
 .theseed-dark-mode a.btn.btn-secondary.tools-btn {
 	background: black;
 	color: #ddd;

--- a/css/default.css
+++ b/css/default.css
@@ -69,7 +69,6 @@ a:focus {
 
 img {
     max-width: 100%;
-/*    height: auto;*/
     margin: 0;
 }
 
@@ -126,7 +125,7 @@ del, s, strike {
 /* 네비 수정 */
 .Liberty .nav-wrapper {
     min-height: 2.8rem;
-    background-color: var(--liberty-navbar-color, #4188f1);
+    background-color: var(--liberty-brand-color, #4188f1);
     position: absolute;
     z-index: 100;
     box-shadow: 0 2px 4px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12);
@@ -174,7 +173,7 @@ del, s, strike {
 }
 
 .Liberty .nav-wrapper .navbar .navbar-nav .nav-item .nav-link:hover {
-	background-color: #023e98;
+	background-color: var(--liberty-brand-dark-color, #214479);
 }
 
 .Liberty .nav-wrapper .navbar .navbar-nav .nav-item .nav-link:hover,
@@ -228,7 +227,7 @@ del, s, strike {
 }
 
 .Liberty .nav-wrapper .navbar .form-inline .btn:hover, .Liberty .nav-wrapper .navbar .form-inline .btn:focus {
-    background-color: var(--liberty-navbar-color, #4188f1);
+    background-color: var(--liberty-brand-color, #4188f1);
     color: #fff;
     outline: 0;
     transition: .3s;
@@ -386,7 +385,7 @@ del, s, strike {
     content: " ";
     width: 15rem;
     display: block;
-    border-bottom: 2px solid var(--liberty-navbar-color, #4188f1);
+    border-bottom: 2px solid var(--liberty-brand-color, #4188f1);
 }
 
 .Liberty .content-wrapper .liberty-sidebar .liberty-right-fixed .live-recent .live-recent-content {
@@ -431,14 +430,14 @@ del, s, strike {
 }
 
 .Liberty .content-wrapper .liberty-sidebar .liberty-right-fixed .live-recent .live-recent-footer .label {
-    background-color: var(--liberty-navbar-color, #5997f3);
+    background-color: var(--liberty-brand-color, #4188f1);
     padding: 0.4rem;
     font-size: 0.8rem;
     font-weight: 400;
 }
 
 .Liberty .content-wrapper .liberty-sidebar .liberty-right-fixed .live-recent .live-recent-footer .label:hover {
-    background-color: #2979f0;
+	background-color: var(--liberty-brand-dark-color, #214479);
 }
 
 .Liberty .content-wrapper .liberty-sidebar .right-ads {
@@ -646,7 +645,7 @@ del, s, strike {
 }
 
 .dropdown-menu .dropdown-item:hover {
-    background-color: var(--liberty-navbar-color, #5997f3);
+    background-color: var(--liberty-brand-color, #4188f1);
     color: #fff;
     transition: 0.3s;
 }
@@ -689,9 +688,20 @@ caption {
 }
 /* 부트스트랩 커스텀 End*/
 
+div.scroll-buttons {
+    position: fixed;
+    float: right;
+    height: 42px;
+    text-align: right;
+    font-size: 1.7em;
+    z-index: 10000;
+    margin-bottom: -10px;
+    bottom: 10px;
+    right: 0px;
+    opacity: 0.8;
+}
 
 div.scroll-buttons a {
-    display: inline-block;
     float: left;
     width: 42px;
     height: 42px;
@@ -706,17 +716,4 @@ div.scroll-buttons a {
 
 .scroll-buttons a:link, .scroll-buttons a:visited {
     color: white;
-}
-
-div.scroll-buttons {
-    position: fixed;
-    float: right;
-    height: 42px;
-    text-align: right;
-    font-size: 1.7em;
-    z-index: 10000;
-    margin-bottom: -10px;
-    bottom: 10px;
-    right: 0px;
-    opacity: 0.8;
 }

--- a/css/default.css
+++ b/css/default.css
@@ -222,6 +222,7 @@ del, s, strike {
 }
 
 .Liberty .nav-wrapper .navbar .form-inline .btn {
+    height: 2rem;
     color: #4f5b63;
     padding: 0.2rem 0.4rem;
 }

--- a/css/default_mobile.css
+++ b/css/default_mobile.css
@@ -90,6 +90,13 @@
         overflow-x: auto;
     }
 
+    .Liberty .content-wrapper .liberty-content .liberty-content-header,
+    .Liberty .content-wrapper .liberty-content .liberty-content-main,
+    .Liberty .content-wrapper .liberty-footer {
+        border-left: none;
+        border-right: none;
+    }
+
     .Liberty .content-wrapper .liberty-content .bottom-ads {
         padding: 0.5rem;
         background-color: #fff;

--- a/layout.vue
+++ b/layout.vue
@@ -226,36 +226,30 @@ export default {
     },
     head() {
         return {
-            meta: [
-                {
-                    name: 'theme-color',
-                    content: this.$store.state.currentTheme === 'light' ?  this.$store.state.config['skin.liberty.brand_color_1'] ?? this.default['brand_color'] : this.default['brand_color']
-                }
-            ]
+            meta: [{ name: 'theme-color', content: this.brand_color }]
         };
     },
     computed: {
-        default() {
-            return {
-                brand_color: this.$store.state.currentTheme === 'light' ? '#4188f1' : '#2d2f34',
-                brand_bright_color: this.$store.state.currentTheme === 'light' ? '#5997f3' : '#2d2f34'
-            };
+        brand_color() {
+            return this.selectByTheme(this.$store.state.config['skin.liberty.brand_color_1'] ?? '#4188f1', '#2d2f34');
         },
         skinConfig() {
             return {
-                '--liberty-navbar-color': this.$store.state.config['skin.liberty.navbar_color'],
+                '--liberty-brand-color': this.brand_color,
+                '--liberty-brand-dark-color': this.selectByTheme(this.$store.state.config['skin.liberty.brand_dark_color_1'] ?? this.darkenColor(this.brand_color), '#16171a'),
+                '--liberty-brand-bright-color': this.selectByTheme(this.$store.state.config['skin.liberty.brand_bright_color_1'] ?? this.lightenColor(this.brand_color), '#383b40'),
                 '--liberty-navbar-logo-image': this.$store.state.config['skin.liberty.navbar_logo_image'],
                 '--liberty-navbar-logo-minimum-width': this.$store.state.config['skin.liberty.navbar_logo_minimum_width'],
                 '--liberty-navbar-logo-width': this.$store.state.config['skin.liberty.navbar_logo_width'],
                 '--liberty-navbar-logo-size': this.$store.state.config['skin.liberty.navbar_logo_size'],
                 '--liberty-navbar-logo-padding': this.$store.state.config['skin.liberty.navbar_logo_padding'],
                 '--liberty-navbar-logo-margin': this.$store.state.config['skin.liberty.navbar_logo_margin'],
-                '--brand-color-1': this.$store.state.config['skin.liberty.brand_color_1'] ?? this.default['brand_color'],
-                '--brand-color-2': this.$store.state.config['skin.liberty.brand_color_2'] ?? this.$store.state.config['skin.liberty.brand_color_1'] ?? this.default['brand_color'],
-                '--brand-bright-color-1': this.$store.state.config['skin.liberty.brand_bright_color_1'] ?? this.default['brand_bright_color'],
-                '--brand-bright-color-2': this.$store.state.config['skin.liberty.brand_bright_color_2'] ?? this.$store.state.config['skin.liberty.brand_bright_color_1'] ?? this.default['brand_bright_color'],
-                '--text-color': this.$store.state.config['skin.liberty.text_color'] ?? this.$store.state.currentTheme === 'light' ? '#373a3c' : '#ddd',
-                '--article-background-color': this.$store.state.config['skin.liberty.article_background_color'] ?? this.$store.state.currentTheme === 'light' ? '#f5f5f5' : '#000',
+                '--brand-color-1': 'var(--liberty-brand-color)',
+                '--brand-color-2': this.selectByTheme(this.$store.state.config['skin.liberty.brand_color_2'] ?? 'var(--liberty-brand-color)', 'var(--liberty-brand-color)'),
+                '--brand-bright-color-1': 'var(--liberty-brand-bright-color)',
+                '--brand-bright-color-2': this.selectByTheme(this.$store.state.config['skin.liberty.brand_bright_color_2'] ?? 'var(--liberty-brand-bright-color)', 'var(--liberty-brand-bright-color)'),
+                '--text-color': this.selectByTheme('#373a3c', '#ddd'),
+                '--article-background-color': this.selectByTheme('#f5f5f5', '#000'),
             };
         },
         requestable() {
@@ -270,6 +264,31 @@ export default {
             else {
                 this.isShowACLMessage = true;
             }
+        },
+        darkenColor(hex, percent=50) {
+            let r = parseInt(hex.substring(1, 3), 16);
+            let g = parseInt(hex.substring(3, 5), 16);
+            let b = parseInt(hex.substring(5, 7), 16);
+
+            r = Math.round(r * (1 - percent / 100));
+            g = Math.round(g * (1 - percent / 100));
+            b = Math.round(b * (1 - percent / 100));
+            
+            return "#" + ((r < 16 ? "0" : "") + r.toString(16)) + ((g < 16 ? "0" : "") + g.toString(16)) + ((b < 16 ? "0" : "") + b.toString(16));
+        },
+        lightenColor(hex, percent=50) {
+            let r = parseInt(hex.substring(1, 3), 16);
+            let g = parseInt(hex.substring(3, 5), 16);
+            let b = parseInt(hex.substring(5, 7), 16);
+
+            r = Math.round(r + (255 - r) * (percent / 100));
+            g = Math.round(g + (255 - g) * (percent / 100));
+            b = Math.round(b + (255 - b) * (percent / 100));
+
+            return "#" + ((r < 16 ? "0" : "") + r.toString(16)) + ((g < 16 ? "0" : "") + g.toString(16)) + ((b < 16 ? "0" : "") + b.toString(16));
+        },
+        selectByTheme(light, dark) {
+            return this.$store.state.currentTheme === 'dark' ? dark : light;
         }
     }
 }

--- a/layout.vue
+++ b/layout.vue
@@ -139,6 +139,7 @@
                         현재 진행 중인 <nuxt-link :to="doc_action_link(user_doc($store.state.session.member.username), 'discuss')">사용자 토론</nuxt-link>이 있습니다.
                     </div>
                     <rev-selector />
+                    <from-selector />
                     <nuxt />
                     <div v-if="$store.state.page.viewName === 'license'">
                         <h2>Liberty skin license</h2>
@@ -192,6 +193,7 @@ import RecentCard from './components/recentCard';
 import SearchForm from './components/searchForm';
 import ContentTool from './components/contentTool';
 import RevSelector from './components/revSelector';
+import FromSelector from './components/fromSelector';
 import License from "raw-loader!./LICENSE";
 
 if (process.browser) {
@@ -211,7 +213,8 @@ export default {
         RecentCard,
         SearchForm,
         ContentTool,
-        RevSelector
+        RevSelector,
+        FromSelector
     },
     data() {
         return {


### PR DESCRIPTION
- skin.liberty.navbar_color를 삭제하고 skin.liberty.brand_color_1로 대체
- 나무위키의 경우 brand 색이 파란 계열이 아니라 navbar link를 hover할 때 색깔이 부자연스러웠으나 관련 method (`lightenColor, darkenColor`)를 추가하여 자연스러운 밝은, 어두운 색이 나오도록 수정