### PR TITLE
fix: rev input text index higher than navbar

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -127,7 +127,7 @@ del, s, strike {
     min-height: 2.8rem;
     background-color: var(--liberty-brand-color, #4188f1);
     position: absolute;
-    z-index: 100;
+    z-index: 300;
     box-shadow: 0 2px 4px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12);
     font-weight: bold;
     left: 0;


### PR DESCRIPTION
역시 리비전 입력란에 고정되어 있는 "r" 텍스트의 z-index가 201이고, dropdown-menu의 z-index가 1000이라 정상적으로 동작할 것 같지만 navbar의 z-index가 100이라 실제로는 그렇게 동작하지 않는 문제가 있었습니다.

navbar의 z-index를 300으로 수정하여 모바일에서 r text가 dropdown-menu 위에 표시되지 않도록 수정했습니다.