### PR TITLE
Apply skinConfig to body

### DIFF
--- a/layout.vue
+++ b/layout.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="Liberty" :style="skinConfig">
+    <div class="Liberty">
         <div id="top"></div>
         <div class="nav-wrapper" :class="{ 'navbar-fixed-top': $store.state.localConfig['liberty.fixed_navbar'] === true }">
             <nav class="navbar navbar-dark">
@@ -36,7 +36,7 @@
                                 <nuxt-link to="/License" class="dropdown-item">라이선스</nuxt-link>
                                 <template v-if="$store.state.session.menus.length">
                                     <div class="dropdown-divider"></div>
-                                    <nuxt-link v-for="m in $store.state.session.menus" :key="m.l" :to="m.l" class="dropdown-item">{{ m.t }}</nuxt-link> 
+                                    <nuxt-link v-for="m in $store.state.session.menus" :key="m.l" :to="m.l" class="dropdown-item">{{ m.t }}</nuxt-link>
                                 </template>
                             </div>
                         </dropdown>
@@ -225,7 +225,8 @@ export default {
     },
     head() {
         return {
-            meta: [{ name: 'theme-color', content: this.brand_color }]
+            meta: [{ name: 'theme-color', content: this.brand_color }],
+            style: [this.skinConfig]
         };
     },
     computed: {
@@ -233,23 +234,30 @@ export default {
             return this.selectByTheme(this.$store.state.config['skin.liberty.brand_color_1'] ?? '#4188f1', '#2d2f34');
         },
         skinConfig() {
-            return {
-                '--liberty-brand-color': this.brand_color,
-                '--liberty-brand-dark-color': this.selectByTheme(this.$store.state.config['skin.liberty.brand_dark_color_1'] ?? this.darkenColor(this.brand_color), '#16171a'),
-                '--liberty-brand-bright-color': this.selectByTheme(this.$store.state.config['skin.liberty.brand_bright_color_1'] ?? this.lightenColor(this.brand_color), '#383b40'),
-                '--liberty-navbar-logo-image': this.$store.state.config['skin.liberty.navbar_logo_image'],
-                '--liberty-navbar-logo-minimum-width': this.$store.state.config['skin.liberty.navbar_logo_minimum_width'],
-                '--liberty-navbar-logo-width': this.$store.state.config['skin.liberty.navbar_logo_width'],
-                '--liberty-navbar-logo-size': this.$store.state.config['skin.liberty.navbar_logo_size'],
-                '--liberty-navbar-logo-padding': this.$store.state.config['skin.liberty.navbar_logo_padding'],
-                '--liberty-navbar-logo-margin': this.$store.state.config['skin.liberty.navbar_logo_margin'],
-                '--brand-color-1': 'var(--liberty-brand-color)',
-                '--brand-color-2': this.selectByTheme(this.$store.state.config['skin.liberty.brand_color_2'] ?? 'var(--liberty-brand-color)', 'var(--liberty-brand-color)'),
-                '--brand-bright-color-1': 'var(--liberty-brand-bright-color)',
-                '--brand-bright-color-2': this.selectByTheme(this.$store.state.config['skin.liberty.brand_bright_color_2'] ?? 'var(--liberty-brand-bright-color)', 'var(--liberty-brand-bright-color)'),
-                '--text-color': this.selectByTheme('#373a3c', '#ddd'),
-                '--article-background-color': this.selectByTheme('#fff', '#000'),
+            const makeStyle = (isDark = false) => {
+                const selectByTheme = (light, dark) => isDark ? dark : light;
+                return Object.entries({
+                    '--liberty-brand-color': selectByTheme(this.$store.state.config['skin.liberty.brand_color_1'] ?? '#4188f1', '#2d2f34'),
+                    '--liberty-brand-dark-color': selectByTheme(this.$store.state.config['skin.liberty.brand_dark_color_1'] ?? this.darkenColor(this.brand_color), '#16171a'),
+                    '--liberty-brand-bright-color': selectByTheme(this.$store.state.config['skin.liberty.brand_bright_color_1'] ?? this.lightenColor(this.brand_color), '#383b40'),
+                    '--liberty-navbar-logo-image': this.$store.state.config['skin.liberty.navbar_logo_image'],
+                    '--liberty-navbar-logo-minimum-width': this.$store.state.config['skin.liberty.navbar_logo_minimum_width'],
+                    '--liberty-navbar-logo-width': this.$store.state.config['skin.liberty.navbar_logo_width'],
+                    '--liberty-navbar-logo-size': this.$store.state.config['skin.liberty.navbar_logo_size'],
+                    '--liberty-navbar-logo-padding': this.$store.state.config['skin.liberty.navbar_logo_padding'],
+                    '--liberty-navbar-logo-margin': this.$store.state.config['skin.liberty.navbar_logo_margin'],
+                    '--brand-color-1': 'var(--liberty-brand-color)',
+                    '--brand-color-2': selectByTheme(this.$store.state.config['skin.liberty.brand_color_2'] ?? 'var(--liberty-brand-color)', 'var(--liberty-brand-color)'),
+                    '--brand-bright-color-1': 'var(--liberty-brand-bright-color)',
+                    '--brand-bright-color-2': selectByTheme(this.$store.state.config['skin.liberty.brand_bright_color_2'] ?? 'var(--liberty-brand-bright-color)', 'var(--liberty-brand-bright-color)'),
+                    '--text-color': selectByTheme('#373a3c', '#ddd'),
+                    '--article-background-color': selectByTheme('#fff', '#000'),
+                }).filter(([, v]) => v).map(([k, v]) => `${k}:${v}`).join(';');
             };
+
+            let style = `body{${makeStyle()}}`;
+            style += `body.theseed-dark-mode{${makeStyle(true)}}`;
+            return style;
         },
         requestable() {
             return this.$store.state.page.data.editable === true && this.$store.state.page.data.edit_acl_message && this.$store.state.page.viewName !== 'notfound';


### PR DESCRIPTION
skinConfig를 body 전체에 적용해 popper, modal 등에도 색상이 적용되도록 합니다.
<img width="273" height="218" alt="image" src="https://github.com/user-attachments/assets/630f00a1-185c-4edd-bec7-d0293a76b12d" />
<img width="364" height="194" alt="image" src="https://github.com/user-attachments/assets/8bda1877-a3ad-462e-a973-243d4eee5341" />
